### PR TITLE
PARAM must have a value attribute as well as datatype and name attributes

### DIFF
--- a/DataLink/DataLink_001.xml
+++ b/DataLink/DataLink_001.xml
@@ -68,7 +68,7 @@
         <PARAM name="standardID" datatype="char" arraysize="32" value="ivo://ivoa.net/std/SODA#sync-1.0" />
         <PARAM name="accessURL" datatype="char" arraysize="43" value="https://ska.srcnet.org/spain-node/soda-sync" />
         <GROUP name="inputParams">
-            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" />
+            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" value="" />
             <PARAM name="POS" datatype="char" arraysize="*" ucd="obs.field" value="" />
             <PARAM name="CIRCLE" datatype="double" arraysize="3" ucd="obs.field" unit="deg" xtype="circle" value="">
             <VALUES>
@@ -83,7 +83,7 @@
         <PARAM name="standardID" datatype="char" arraysize="33" value="ivo://ivoa.net/std/SODA#async-1.0" />
         <PARAM name="accessURL" datatype="char" arraysize="44" value="https://ska.srcnet.org/spain-node/soda-async" />
         <GROUP name="inputParams">
-            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" />
+            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" value="" />
             <PARAM name="POS" datatype="char" arraysize="*" ucd="obs.field" value="" />
             <PARAM name="CIRCLE" datatype="double" arraysize="3" ucd="obs.field" unit="deg" xtype="circle" value="">
             <VALUES>

--- a/DataLink/DataLink_002.xml
+++ b/DataLink/DataLink_002.xml
@@ -68,7 +68,7 @@
         <PARAM name="standardID" datatype="char" arraysize="32" value="ivo://ivoa.net/std/SODA#sync-1.0" />
         <PARAM name="accessURL" datatype="char" arraysize="43" value="https://ska.srcnet.org/china-node/soda-sync" />
         <GROUP name="inputParams">
-            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" />
+            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" value="" />
             <PARAM name="POS" datatype="char" arraysize="*" ucd="obs.field" value="" />
             <PARAM name="CIRCLE" datatype="double" arraysize="3" ucd="obs.field" unit="deg" xtype="circle" value="">
             <VALUES>
@@ -83,7 +83,7 @@
         <PARAM name="standardID" datatype="char" arraysize="33" value="ivo://ivoa.net/std/SODA#async-1.0" />
         <PARAM name="accessURL" datatype="char" arraysize="44" value="https://ska.srcnet.org/china-node/soda-async" />
         <GROUP name="inputParams">
-            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" />
+            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" value="" />
             <PARAM name="POS" datatype="char" arraysize="*" ucd="obs.field" value="" />
             <PARAM name="CIRCLE" datatype="double" arraysize="3" ucd="obs.field" unit="deg" xtype="circle" value="">
             <VALUES>

--- a/DataLink/DataLink_003.xml
+++ b/DataLink/DataLink_003.xml
@@ -118,7 +118,7 @@
         <PARAM name="standardID" datatype="char" arraysize="33" value="ivo://ivoa.net/std/SODA#async-1.0" />
         <PARAM name="accessURL" datatype="char" arraysize="44" value="http://ska.srcnet.org/china-node/soda-async" />
         <GROUP name="inputParams">
-            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" />
+            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" value="" />
            <PARAM name="POS" datatype="char" arraysize="*" ucd="obs.field" value="" />
             <PARAM name="CIRCLE" datatype="double" arraysize="3" ucd="obs.field" unit="deg" xtype="circle" value="">
             <VALUES>
@@ -133,7 +133,7 @@
         <PARAM name="standardID" datatype="char" arraysize="33" value="ivo://ivoa.net/std/SODA#async-1.0" />
         <PARAM name="accessURL" datatype="char" arraysize="44" value="http://ska.srcnet.org/china-node/soda-async" />
         <GROUP name="inputParams">
-            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" />
+            <PARAM name="ID" datatype="char" arraysize="30" ucd="meta.id;meta.dataset" ref="ID" value="" />
            <PARAM name="POS" datatype="char" arraysize="*" ucd="obs.field" value="" />
             <PARAM name="CIRCLE" datatype="double" arraysize="3" ucd="obs.field" unit="deg" xtype="circle" value="">
             <VALUES>


### PR DESCRIPTION
The VOTable standard specifies that a "value" attribute is mandatory to be in PARAM: https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html#elem:PARAM

I updated the datalink tables with a null value